### PR TITLE
Fix WebsocketError kind for LCUWebSocket by using client request instead of URL

### DIFF
--- a/irelia/src/lib.rs
+++ b/irelia/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(lazy_cell)]
+#![feature(lazy_cell, test)]
 
 //! Irelia is an async set of bindings to the LCU API
 //!

--- a/irelia/src/ws.rs
+++ b/irelia/src/ws.rs
@@ -60,7 +60,7 @@ impl LCUWebSocket {
         req.headers_mut()
             .insert("Authorization", HeaderValue::from_str(&pass).unwrap());
 
-        let (stream, _) = connect_async_tls_with_config(url, None, false, Some(connector))
+        let (stream, _) = connect_async_tls_with_config(req, None, false, Some(connector))
             .await
             .map_err(LCUError::WebsocketError)?;
 

--- a/irelia/src/ws.rs
+++ b/irelia/src/ws.rs
@@ -151,3 +151,18 @@ impl Stream for LCUWebSocket {
         self.client_reciever.poll_recv(cx)
     }
 }
+
+#[cfg(test)]
+mod test {
+    extern crate test;
+
+    use tokio;
+
+    use super::LCUWebSocket;
+
+    #[tokio::test]
+    #[ignore]
+    async fn it_inits() {
+        let _ws_client = LCUWebSocket::new().await.unwrap();
+    }
+}


### PR DESCRIPTION
Should resolve #7 ! 💚

URL was incorrectly passed to the `connect_async_tls_with_config` function instead of the client request.
https://docs.rs/tokio-tungstenite/latest/tokio_tungstenite/fn.connect_async_tls_with_config.html

I also added an ignored test that I used to verify that that error was fixed on my end. I tried following the testing layout you already have for the project. :3