### PR TITLE
Add missing/new event types

### DIFF
--- a/irelia/src/ws.rs
+++ b/irelia/src/ws.rs
@@ -39,6 +39,11 @@ pub enum RequestType {
 pub enum EventType {
     OnJsonApiEvent,
     OnLcdEvent,
+    OnLog,
+    OnRegionLocaleChanged,
+    OnServiceProxyAsyncEvent,
+    OnServiceProxyMethodEvent,
+    OnServiceProxyUuidEvent,
     OnJsonApiEventCallback(String),
     OnLcdEventCallback(String),
 }
@@ -75,6 +80,17 @@ impl LCUWebSocket {
                     let endpoint = match endpoint {
                         EventType::OnJsonApiEvent => String::from("OnJsonApiEvent"),
                         EventType::OnLcdEvent => String::from("OnLcdEvent"),
+                        EventType::OnLog => String::from("OnLog"),
+                        EventType::OnRegionLocaleChanged => String::from("OnRegionLocaleChanged"),
+                        EventType::OnServiceProxyAsyncEvent => {
+                            String::from("OnServiceProxyAsyncEvent")
+                        }
+                        EventType::OnServiceProxyMethodEvent => {
+                            String::from("OnServiceProxyMethodEvent")
+                        }
+                        EventType::OnServiceProxyUuidEvent => {
+                            String::from("OnServiceProxyUuidEvent")
+                        }
                         EventType::OnJsonApiEventCallback(callback) => {
                             format!("OnJsonApiEvent{}", callback.replace('/', "_"))
                         }


### PR DESCRIPTION
I added missing or new event types that aren't part of `OnJsonApiEvent` or `OnLcdsEvent`. These are referenced from the `/Help` endpoint. I've attached a JSON response file below where you can find these events under the `events` field.

[help-json.zip](https://github.com/AlsoSylv/Irelia/files/11949424/help-json.zip)